### PR TITLE
fix(index): incorrect contextual "this" reference

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -117,7 +117,7 @@ export class WebpackLoader extends Loader {
           const result = __webpack_require__(path);
           return this._getActualResult(result, resolve, reject);
         } catch (_) {}
-        require.ensure([], function(require) {
+        require.ensure([], require => {
           // if failed, try resolving via the context created by the plugin //
           const result = require('aurelia-loader-context/' + path);
           return this._getActualResult(result, resolve, reject);


### PR DESCRIPTION
The require.ensure method on line 120 was using a generic function. Therefore, the `this` scope was being lost when trying to reference the _getActualResul` method. Changing it to a fat arrow method fixes the issue as the scope of "this" remains in reference to the class containing this method.
