### PR TITLE
chore(package) update hot module reload

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "release": "aurelia-tools changelog"
   },
   "dependencies": {
-    "aurelia-hot-module-reload": "^0.1.0",
+    "aurelia-hot-module-reload": "^0.2.0",
     "aurelia-loader": "^1.0.0",
     "aurelia-metadata": "^1.0.2",
     "aurelia-pal": "^1.1.1"


### PR DESCRIPTION
I've only increased the version of the aurelia-hot-module-reload package to the latest after noticing it was outdated here. Test on my setup and everything still works afterward.