### PR TITLE
fix(loader-webpack): handle HMR changes also in async modules

### DIFF
--- a/dist/amd/aurelia-loader-webpack.js
+++ b/dist/amd/aurelia-loader-webpack.js
@@ -179,7 +179,7 @@ define(["require", "exports", "aurelia-metadata", "aurelia-loader", "aurelia-pal
                             if (!__webpack_require__.m[asyncModuleId]) return [3 /*break*/, 4];
                             if (defaultHMR && module.hot && this.hmrContext) {
                                 module.hot.accept(moduleId, function () { return _this.hmrContext.handleModuleChange(moduleId, module.hot); });
-                                module.hot.accept(asyncModuleId, function () { });
+                                module.hot.accept(asyncModuleId, function () { return _this.hmrContext.handleModuleChange(moduleId, module.hot); });
                             }
                             callback = __webpack_require__(asyncModuleId);
                             return [4 /*yield*/, new Promise(callback)];

--- a/dist/commonjs/aurelia-loader-webpack.js
+++ b/dist/commonjs/aurelia-loader-webpack.js
@@ -181,7 +181,7 @@ var WebpackLoader = (function (_super) {
                         if (!__webpack_require__.m[asyncModuleId]) return [3 /*break*/, 4];
                         if (defaultHMR && module.hot && this.hmrContext) {
                             module.hot.accept(moduleId, function () { return _this.hmrContext.handleModuleChange(moduleId, module.hot); });
-                            module.hot.accept(asyncModuleId, function () { });
+                            module.hot.accept(asyncModuleId, function () { return _this.hmrContext.handleModuleChange(moduleId, module.hot); });
                         }
                         callback = __webpack_require__(asyncModuleId);
                         return [4 /*yield*/, new Promise(callback)];

--- a/dist/doc-temp/aurelia-loader-webpack.js
+++ b/dist/doc-temp/aurelia-loader-webpack.js
@@ -179,7 +179,7 @@ define("aurelia-loader-webpack", ["require", "exports", "aurelia-metadata", "aur
                             if (!__webpack_require__.m[asyncModuleId]) return [3 /*break*/, 4];
                             if (defaultHMR && module.hot && this.hmrContext) {
                                 module.hot.accept(moduleId, function () { return _this.hmrContext.handleModuleChange(moduleId, module.hot); });
-                                module.hot.accept(asyncModuleId, function () { });
+                                module.hot.accept(asyncModuleId, function () { return _this.hmrContext.handleModuleChange(moduleId, module.hot); });
                             }
                             callback = __webpack_require__(asyncModuleId);
                             return [4 /*yield*/, new Promise(callback)];

--- a/dist/es2015/aurelia-loader-webpack.js
+++ b/dist/es2015/aurelia-loader-webpack.js
@@ -114,7 +114,7 @@ export class WebpackLoader extends Loader {
             if (__webpack_require__.m[asyncModuleId]) {
                 if (defaultHMR && module.hot && this.hmrContext) {
                     module.hot.accept(moduleId, () => this.hmrContext.handleModuleChange(moduleId, module.hot));
-                    module.hot.accept(asyncModuleId, () => { });
+                    module.hot.accept(asyncModuleId, () => this.hmrContext.handleModuleChange(moduleId, module.hot));
                 }
                 const callback = __webpack_require__(asyncModuleId);
                 return yield new Promise(callback);

--- a/dist/es2017/aurelia-loader-webpack.js
+++ b/dist/es2017/aurelia-loader-webpack.js
@@ -103,7 +103,7 @@ export class WebpackLoader extends Loader {
         if (__webpack_require__.m[asyncModuleId]) {
             if (defaultHMR && module.hot && this.hmrContext) {
                 module.hot.accept(moduleId, () => this.hmrContext.handleModuleChange(moduleId, module.hot));
-                module.hot.accept(asyncModuleId, () => { });
+                module.hot.accept(asyncModuleId, () => this.hmrContext.handleModuleChange(moduleId, module.hot));
             }
             const callback = __webpack_require__(asyncModuleId);
             return await new Promise(callback);

--- a/dist/native-modules/aurelia-loader-webpack.js
+++ b/dist/native-modules/aurelia-loader-webpack.js
@@ -179,7 +179,7 @@ var WebpackLoader = (function (_super) {
                         if (!__webpack_require__.m[asyncModuleId]) return [3 /*break*/, 4];
                         if (defaultHMR && module.hot && this.hmrContext) {
                             module.hot.accept(moduleId, function () { return _this.hmrContext.handleModuleChange(moduleId, module.hot); });
-                            module.hot.accept(asyncModuleId, function () { });
+                            module.hot.accept(asyncModuleId, function () { return _this.hmrContext.handleModuleChange(moduleId, module.hot); });
                         }
                         callback = __webpack_require__(asyncModuleId);
                         return [4 /*yield*/, new Promise(callback)];

--- a/dist/system/aurelia-loader-webpack.js
+++ b/dist/system/aurelia-loader-webpack.js
@@ -194,7 +194,7 @@ System.register(["aurelia-metadata", "aurelia-loader", "aurelia-pal"], function 
                                     if (!__webpack_require__.m[asyncModuleId]) return [3 /*break*/, 4];
                                     if (defaultHMR && module.hot && this.hmrContext) {
                                         module.hot.accept(moduleId, function () { return _this.hmrContext.handleModuleChange(moduleId, module.hot); });
-                                        module.hot.accept(asyncModuleId, function () { });
+                                        module.hot.accept(asyncModuleId, function () { return _this.hmrContext.handleModuleChange(moduleId, module.hot); });
                                     }
                                     callback = __webpack_require__(asyncModuleId);
                                     return [4 /*yield*/, new Promise(callback)];

--- a/src/aurelia-loader-webpack.ts
+++ b/src/aurelia-loader-webpack.ts
@@ -128,7 +128,7 @@ export class WebpackLoader extends Loader {
     if (__webpack_require__.m[asyncModuleId]) {
       if (defaultHMR && module.hot && this.hmrContext) {
         module.hot.accept(moduleId, () => this.hmrContext.handleModuleChange(moduleId, module.hot));
-        module.hot.accept(asyncModuleId, () => {});
+        module.hot.accept(asyncModuleId, () => this.hmrContext.handleModuleChange(moduleId, module.hot));
       }
       const callback = __webpack_require__(asyncModuleId) as (callback: (moduleExports: any) => void) => void;
       return await new Promise(callback);


### PR DESCRIPTION
Fixes #39 

I do not know if the original empty function for explicitly *not* handling HMR changes in async modules was a conscious and deliberate choice. Because of this, while I don't think this change should break anything, I'm not 100% sure.