### PR TITLE
fix(eachModule): shortcircuit the iteration when callback returns true

### DIFF
--- a/src/aurelia-loader-webpack.ts
+++ b/src/aurelia-loader-webpack.ts
@@ -91,12 +91,13 @@ export class WebpackLoader extends Loader {
       const registry = __webpack_require__.c;
       const cachedModuleIds = Object.getOwnPropertyNames(registry);
       cachedModuleIds
-        .forEach(moduleId => {
+        .some(moduleId => {
           const moduleExports = registry[moduleId].exports;
           if (typeof moduleExports === 'object') {
-            callback(moduleId, moduleExports);
+            return callback(moduleId, moduleExports);
           }
-        })
+          return false;
+        });
     };
   }
 

--- a/src/aurelia-loader-webpack.ts
+++ b/src/aurelia-loader-webpack.ts
@@ -91,6 +91,10 @@ export class WebpackLoader extends Loader {
       const registry = __webpack_require__.c;
       const cachedModuleIds = Object.getOwnPropertyNames(registry);
       cachedModuleIds
+        // Note: we use .some here like a .forEach that can be "break"ed out of.
+        // It will stop iterating only when a truthy value is returned.
+        // Even though the docs say "true" explicitly, loader-default also goes by truthy
+        // and this is to keep it consistent with that.
         .some(moduleId => {
           const moduleExports = registry[moduleId].exports;
           if (typeof moduleExports === 'object') {


### PR DESCRIPTION
Will make `eachModule` behave consistently with `loader-default` and how the public API describes it.