### PR TITLE
WebpackPlugin.loadText() returns object instead of string with webpack/aurelia-webpack-plugin 5

### DIFF
--- a/src/aurelia-loader-webpack.ts
+++ b/src/aurelia-loader-webpack.ts
@@ -1,6 +1,6 @@
-import {Origin} from 'aurelia-metadata';
-import {Loader, TemplateRegistryEntry, LoaderPlugin} from 'aurelia-loader';
-import {DOM, PLATFORM} from 'aurelia-pal';
+import { Loader, LoaderPlugin as AureliaLoaderPlugin, TemplateRegistryEntry } from 'aurelia-loader';
+import { Origin } from 'aurelia-metadata';
+import { DOM, PLATFORM } from 'aurelia-pal';
 
 export type LoaderPlugin = { fetch: (address: string) => Promise<TemplateRegistryEntry> | TemplateRegistryEntry };
 
@@ -49,7 +49,7 @@ export function ensureOriginOnExports(moduleExports: any, moduleId: string) {
 */
 export class WebpackLoader extends Loader {
   moduleRegistry = Object.create(null);
-  loaderPlugins = Object.create(null) as { [name: string]: LoaderPlugin & { hot?: (moduleId: string) => void } };
+  loaderPlugins = Object.create(null) as { [name: string]: AureliaLoaderPlugin & { hot?: (moduleId: string) => void } };
   modulesBeingLoaded = new Map<string, Promise<any>>();
   templateLoader: TextTemplateLoader;
   hmrContext: {
@@ -85,7 +85,7 @@ export class WebpackLoader extends Loader {
         }
         return entry;
       }
-    } as LoaderPlugin);
+    } as AureliaLoaderPlugin);
 
     PLATFORM.eachModule = callback => {
       const registry = __webpack_require__.c;
@@ -232,7 +232,7 @@ export class WebpackLoader extends Loader {
       // we're dealing with a file loaded using the css-loader:
       return defaultExport.toString();
     }
-    return result;
+    return typeof result === "string" ? result : defaultExport;
   }
 
   /**
@@ -250,7 +250,7 @@ export class WebpackLoader extends Loader {
   * @param pluginName The name of the plugin.
   * @param implementation The plugin implementation.
   */
-  addPlugin(pluginName: string, implementation: LoaderPlugin) {
+  addPlugin(pluginName: string, implementation: AureliaLoaderPlugin) {
     this.loaderPlugins[pluginName] = implementation;
   }
 }


### PR DESCRIPTION
I have spent a couple of days getting `aurelia-webpack-plugin@5.0.0` and webpack 5 to work with our Aurelia 1 based products.

I found a few issues with that I will submit fixes to in separate PR(s) to aurelia-webpack-plugin repository, but I also got an error that needs to be fixed in the aurelia-loader-webpack package.

__The problem I found is in the `WebpackLoader.loadText` method.  After upgrading to __webpack 5__ and __aurelia-webpack-plugin 5__, this method returned an object instead of a string when loading HTML templates.__

The object that was returned from the method instead of the expected string looked like this:
```javascript
{ 
  get default(): "<template>....", // The template
  Symbol(Symbol.toStringTag): "Module"
  __esModule: true
}
```

To fix this issue so that it will return a string for webpack/aurelia-webpack-plugin _5_ without breaking the behavior when used with webpack/aurelia-webpack-plugin _4_, I simply modified the return statement on the last line of the function, since the value of the `defaultExport` variable is the string that should be returned:

```typescript
export class WebpackLoader extends Loader {
  //...
  async loadText(url: string) {
    const result = await this.loadModule(url, false);
    // css-loader could use esModule:true
    const defaultExport = result && result.__esModule ? result.default : result;
    if (defaultExport instanceof Array && defaultExport[0] instanceof Array && defaultExport.hasOwnProperty('toString')) {
      // we're dealing with a file loaded using the css-loader:
      return defaultExport.toString();
    }
    // CHANGE START
    // before: 
    // return result;
    // after:
    return typeof result === "string" ? result : defaultExport;
    // CHANGE END
  }
  //...
}
```

_PS! I also needed to make one more small change to the existing code for the typescript compilation to succeed. There was a name collision between the exported type `LoaderPlugin` and the imported type `LoaderPlugin` from `aurelia-loader`. To resolve the conflict I gave the imported type an alias._

@EisenbergEffect I hope this approval of the PR and release of a new version will be prioritized ASAP (even before looking at the pending dependabot PRs), as I am confident that this plus the other few fixes that I plan to submit to the aurelia-webpack-plugin repository will improve the overall robustness of Aurelia 1 with webpack 5. The webpack configuration used in our products is based on the aurelia cli generated webpack configuration, but over time got some more advanced configuration options. The testing I have done with our products probably revealed a few issues that may not have been covered by earlier tests.

_Background: The company I work for has a product suite with multiple TypeScript/Webpack based Aurelia 1 apps that share a common Aurelia 1 UI library and many other components like f.ex. a common webpack builder library._
